### PR TITLE
Modify: 사이트 url을 반영하도록 메타데이터 수정

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
       summary: `테니스치다 손목 삔 개발자`,
     },
     description: `A starter blog demonstrating what Gatsby can do.`,
-    siteUrl: `https://gatsbystarterblogsource.gatsbyjs.io/`,
+    siteUrl: `https://milooy.github.io/`,
     social: {
       twitter: `jayjinjay`,
     },


### PR DESCRIPTION
## 작업 배경
- 현재 블로그의 메타데이터 중 `siteUrl` 값이 gatsby-starter에서 초기 세팅 해주는 더미 값으로 들어가 있습니다
- xml을 파싱하여 rss 피드에서 사용할 수 있도록 하려 했으나 더미 값이 파싱되어 원본 포스트로 이동하는 등의 목적으로 활용할 수 없는 상황입니다

## 변경 사항
- 기본 값으로 들어 있는 `siteUrl` 값을 현재 사이트 주소를 반영하도록 변경